### PR TITLE
format_cd_hit_output: increase tool version 

### DIFF
--- a/tools/format_cd_hit_output/format_cd_hit_output.xml
+++ b/tools/format_cd_hit_output/format_cd_hit_output.xml
@@ -1,4 +1,4 @@
-<tool id="format_cd_hit_output" name="Format cd-hit outputs" version="1.0.0">
+<tool id="format_cd_hit_output" name="Format cd-hit outputs" version="1.0.0+galaxy1">
     <description>to rename representative sequences with cluster name and/or extract distribution inside clusters given a mapping file</description>
 
     <requirements>


### PR DESCRIPTION
I think it is necessary to increase the tool version in order to include those changes https://github.com/ASaiM/galaxytools/commit/ac8bb9634dce0075a70c3b772a67aa1d5c846b03 in the wrapper @bebatut. It is related with a recent error report we got:

`AttributeError: 'dict' object has no attribute 'has_key'`